### PR TITLE
[hyperHTML] Avoid non keyed / trashed behaviour

### DIFF
--- a/examples/setup/hyperHTML/temperature/view.js
+++ b/examples/setup/hyperHTML/temperature/view.js
@@ -1,7 +1,7 @@
 import { wire } from "hyperhtml/esm";
 import { safe, wrap } from "../../common/handler";
 
-const precipitationOption = ({ model, actions, id, value, label }) => wire()`
+const precipitationOption = ({ model, actions, id, value, label }) => wire(model, `:precip-${id}`)`
   <span>
     <input type="radio" id="${id}" name="precipitation" value="${value}"
       checked="${model.precipitation === value}"
@@ -11,7 +11,7 @@ const precipitationOption = ({ model, actions, id, value, label }) => wire()`
 `;
 
 export const createView = actions => model => {
-    const w = wire(model);
+    const w = wire(model, ':view');
     const el = w`
       <div>
         <div>


### PR DESCRIPTION
One peculiarity of _hyperHTML_ is the ability to relate multiple views to a single reference.

That is obtained via `wire(obj, `${optionalType}:${uniqueId}`)` where `optionalType` can be either `html` (default) or `svg` and the unique id in this demo case is straight forward to retrieve.

Thanks for considering this change since it's crucial for benchmark purposes.