### PR TITLE
Factor-in a proposer between actions and acceptors for SAM

### DIFF
--- a/examples/sandbox/sam/src/temperature/actions.js
+++ b/examples/sandbox/sam/src/temperature/actions.js
@@ -1,11 +1,11 @@
-export const createActions = acceptor => ({
-  togglePrecipitations: evt => acceptor.togglePrecipitations(evt.target.checked),
+export const createActions = propose => ({
+  togglePrecipitations: evt => propose({ precipitations: evt.target.checked }),
 
-  changePrecipitation: evt => acceptor.changePrecipitation(evt.target.value),
+  changePrecipitation: evt => propose({ precipitation: evt.target.value }),
 
-  editDate: evt => acceptor.editDate(evt.target.value),
+  editDate: evt => propose({ date: evt.target.value }),
 
-  increase: amount => () => acceptor.increase(amount),
+  increase: amount => () => propose({ amount }),
 
-  changeUnits: () => acceptor.changeUnits(),
+  changeUnits: () => propose({ changeUnits: true }),
 });

--- a/examples/sandbox/sam/src/temperature/index.js
+++ b/examples/sandbox/sam/src/temperature/index.js
@@ -1,4 +1,5 @@
 import { createAcceptor } from "./acceptor";
+import { createProposer } from "./proposer";
 import { createActions } from "./actions";
 import { createView } from "./view";
 import { state } from "./state";
@@ -12,7 +13,7 @@ export const createTemperature = update => ({
     units: "C"
   }),
 
-  view: createView(createActions(createAcceptor(update))),
+  view: createView(createActions(createProposer(createAcceptor(update)))),
 
   state
 });

--- a/examples/sandbox/sam/src/temperature/proposer.js
+++ b/examples/sandbox/sam/src/temperature/proposer.js
@@ -1,0 +1,28 @@
+export const createProposer = acceptor => proposal => {
+
+  const {
+    precipitations,
+    precipitation,
+    date,
+    amount,
+    changeUnits
+  } = proposal;
+
+  if (proposing(precipitations)) {
+    acceptor.togglePrecipitations(precipitations)
+  }
+  if (proposing(precipitation)) {
+    acceptor.changePrecipitation(precipitation)
+  }
+  if (proposing(date)) {
+    acceptor.editDate(date)
+  }
+  if (proposing(amount)) {
+    acceptor.increase(amount)
+  }
+  if (proposing(changeUnits)) {
+    acceptor.changeUnits()
+  }
+};
+
+const proposing = (x) => typeof x !== 'undefined';

--- a/examples/sandbox/sam/src/temperature/view.js
+++ b/examples/sandbox/sam/src/temperature/view.js
@@ -27,7 +27,7 @@ export const createView = actions => model => html`
     </div>
     <span>Temperature: </span>
     <span class="tempValue">${model.value}</span>&deg;<span class="tempUnits">${model.units}</span>
-    <span>${model.comments}</span>
+    <span>${model.comment}</span>
     <div>
       <button class="btn btn-default increase" onclick="${actions.increase(1)}">Increase</button>
       <button class="btn btn-default decrease" onclick="${actions.increase(-1)}">Decrease</button>


### PR DESCRIPTION
Per JJ, the mapping from actions to acceptors should happen closer to the model (rather than in the actions).  So I've added a "proposer" in between actions and acceptors, essentially to route proposals to the appropriate acceptors.  I also fixed a small bug to display the state's `comment` in the view.

Questions that remain,
 - If multiple acceptors run from a single proposal should `update()` be called multiple times?  This is the current behavior but might violate the idea of a discrete "step."
 - Does it matter if state (e.g. the `comment`) is attached to the model, versus being its own object?
 - Is there a better proposal structure?  I emulated what I've seen JJ doing and tried to make it look as clean as possible.  It might be worth thinking about more.

Curious what you think @foxdonut!  Feel free to use/merge this PR, but we can also just use it for discussion.